### PR TITLE
Add new connection setting: edgedb_include_typeoids_in_output

### DIFF
--- a/src/backend/utils/adt/arrayfuncs.c
+++ b/src/backend/utils/adt/arrayfuncs.c
@@ -28,6 +28,7 @@
 #include "utils/arrayaccess.h"
 #include "utils/builtins.h"
 #include "utils/datum.h"
+#include "utils/guc.h"
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
 #include "utils/typcache.h"
@@ -1591,7 +1592,9 @@ array_send(PG_FUNCTION_ARGS)
 	/* Send the array header information */
 	pq_sendint(&buf, ndim, 4);
 	pq_sendint(&buf, AARR_HASNULL(v) ? 1 : 0, 4);
-	pq_sendint(&buf, element_type, sizeof(Oid));
+	if (edgedb_include_typeoids_in_output) {
+		pq_sendint(&buf, element_type, sizeof(Oid));
+	}
 	for (i = 0; i < ndim; i++)
 	{
 		pq_sendint(&buf, dim[i], 4);

--- a/src/backend/utils/adt/rowtypes.c
+++ b/src/backend/utils/adt/rowtypes.c
@@ -23,6 +23,7 @@
 #include "libpq/pqformat.h"
 #include "miscadmin.h"
 #include "utils/builtins.h"
+#include "utils/guc.h"
 #include "utils/lsyscache.h"
 #include "utils/typcache.h"
 
@@ -728,7 +729,9 @@ record_send(PG_FUNCTION_ARGS)
 		if (tupdesc->attrs[i]->attisdropped)
 			continue;
 
-		pq_sendint(&buf, column_type, sizeof(Oid));
+		if (edgedb_include_typeoids_in_output) {
+			pq_sendint(&buf, column_type, sizeof(Oid));
+		}
 
 		if (nulls[i])
 		{

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -473,6 +473,8 @@ int			tcp_keepalives_idle;
 int			tcp_keepalives_interval;
 int			tcp_keepalives_count;
 
+bool		edgedb_include_typeoids_in_output = true;
+
 /*
  * SSL renegotiation was been removed in PostgreSQL 9.5, but we tolerate it
  * being set to zero (meaning never renegotiate) for backward compatibility.
@@ -802,6 +804,18 @@ static const unit_conversion time_unit_conversion_table[] =
 
 static struct config_bool ConfigureNamesBool[] =
 {
+	{
+		{"edgedb_include_typeoids_in_output", PGC_USERSET, CLIENT_CONN,
+			gettext_noop("EdgeDB: include typeoids in output."),
+			NULL
+		},
+		&edgedb_include_typeoids_in_output,
+		true,
+		NULL, NULL, NULL
+	},
+
+	/* end of EdgeDB custom settings */
+
 	{
 		{"enable_seqscan", PGC_USERSET, QUERY_TUNING_METHOD,
 			gettext_noop("Enables the planner's use of sequential-scan plans."),

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -272,6 +272,8 @@ extern int	tcp_keepalives_count;
 extern bool trace_sort;
 #endif
 
+extern PGDLLIMPORT bool edgedb_include_typeoids_in_output;
+
 /*
  * Functions exported by guc.c
  */


### PR DESCRIPTION
This is a custom setting that allows to omit transferring type OIDs
in serialized records and arrays in binary protocol.