### PR TITLE
Enforce strict separation between timezone-aware and local date/time

### DIFF
--- a/src/include/utils/datetime.h
+++ b/src/include/utils/datetime.h
@@ -338,4 +338,13 @@ extern TimeZoneAbbrevTable *ConvertTimeZoneAbbrevs(struct tzEntry *abbrevs,
 					   int n);
 extern void InstallTimeZoneAbbrevs(TimeZoneAbbrevTable *tbl);
 
+#define EDGEDB_TZ_OPTIONAL 0
+#define EDGEDB_TZ_REQUIRED 1
+#define EDGEDB_TZ_PROHIBITED 2
+
+extern int EdgeDBDecodeDateTime(char **field, int *ftype,
+		int nf, int *dtype,
+		struct pg_tm *tm, fsec_t *fsec, int *tzp,
+		int tzmode);
+
 #endif							/* DATETIME_H */

--- a/src/include/utils/formatting.h
+++ b/src/include/utils/formatting.h
@@ -19,6 +19,7 @@
 
 #include "fmgr.h"
 
+#include "utils/date.h"
 
 extern char *str_tolower(const char *buff, size_t nbytes, Oid collid);
 extern char *str_toupper(const char *buff, size_t nbytes, Oid collid);
@@ -27,5 +28,9 @@ extern char *str_initcap(const char *buff, size_t nbytes, Oid collid);
 extern char *asc_tolower(const char *buff, size_t nbytes);
 extern char *asc_toupper(const char *buff, size_t nbytes);
 extern char *asc_initcap(const char *buff, size_t nbytes);
+
+extern void EdgeDBToTimestamp(
+	text *date_txt, text *fmt,
+	struct pg_tm *tm, fsec_t *fsec, int tzmode);
 
 #endif


### PR DESCRIPTION
* Add a "edgedb_relaxed_datetime" GUC to force date_in, time_in,
  timestamp_in, and timestamptz_in to reject/require an explicit
  timezone.

* Make it possible to implement custom to_timezone() and
  to_timestonetz() functions requiring/rejecting an explicit
  timezone.