### PR TITLE
Avoid table rewrite when adding nullable columns of constrained domains

### DIFF
--- a/src/backend/utils/cache/typcache.c
+++ b/src/backend/utils/cache/typcache.c
@@ -1410,6 +1410,21 @@ DomainHasConstraints(Oid type_id)
 	return (typentry->domainData != NULL);
 }
 
+/*
+ * DomainIsStrict --- routine to check if a domain has a NOT NULL constraint
+ */
+bool
+DomainIsStrict(Oid type_id)
+{
+	HeapTuple	tup;
+	Form_pg_type typTup;
+
+	tup = SearchSysCacheCopy1(TYPEOID, ObjectIdGetDatum(type_id));
+	if (!HeapTupleIsValid(tup))
+		elog(ERROR, "cache lookup failed for type %u", type_id);
+	typTup = (Form_pg_type) GETSTRUCT(tup);
+	return typTup->typnotnull;
+}
 
 /*
  * array_element_has_equality and friends are helper routines to check

--- a/src/include/utils/typcache.h
+++ b/src/include/utils/typcache.h
@@ -184,6 +184,8 @@ extern void UpdateDomainConstraintRef(DomainConstraintRef *ref);
 
 extern bool DomainHasConstraints(Oid type_id);
 
+extern bool DomainIsStrict(Oid type_id);
+
 extern TupleDesc lookup_rowtype_tupdesc(Oid type_id, int32 typmod);
 
 extern TupleDesc lookup_rowtype_tupdesc_noerror(Oid type_id, int32 typmod,


### PR DESCRIPTION
Postgres has an optimization whereby it skips a full table rewrite if a
default was specified or the column is nullable, however this
optimization is skipped if a domain has constraints defined on it,
because `CHECK` constraints get invoked on NULL values and there is no
way for Postgres to know how that NULL value affects the constraint
without evaluating it.  Unfortunatly, there's no direct way of
evaluating domain constraints from that part of `ALTER TABLE`
processing.  However, EdgeQL does not support checking for an empty
value in scalar constraints, so we can safely skip the table rewrite on
nullable columns even if there are constraints (but still keep it for
domains marked as `NOT NULL` just in case).
