### PR TITLE
Use `SearchSysCache` instead of `SearchSysCacheCopy` in `DomainIsStrict`

### DIFF
--- a/src/backend/utils/cache/typcache.c
+++ b/src/backend/utils/cache/typcache.c
@@ -1418,12 +1418,15 @@ DomainIsStrict(Oid type_id)
 {
 	HeapTuple	tup;
 	Form_pg_type typTup;
+	bool notnull;
 
-	tup = SearchSysCacheCopy1(TYPEOID, ObjectIdGetDatum(type_id));
+	tup = SearchSysCache1(TYPEOID, ObjectIdGetDatum(type_id));
 	if (!HeapTupleIsValid(tup))
 		elog(ERROR, "cache lookup failed for type %u", type_id);
 	typTup = (Form_pg_type) GETSTRUCT(tup);
-	return typTup->typnotnull;
+	notnull = typTup->typnotnull;
+	ReleaseSysCache(tup);
+	return notnull;
 }
 
 /*


### PR DESCRIPTION
We are only reading the entry, so no need to obtain a modifyable copy of the tuple.